### PR TITLE
solve problem when noob IA seems to pass it's turn

### DIFF
--- a/tictactoe.js
+++ b/tictactoe.js
@@ -629,7 +629,7 @@ $(document).ready(function(){
 							return false;
 						});
 						while(true){
-							ai = Math.floor(Math.random()*9+1);
+							ai = Math.floor(Math.random()*9);
 							if(humanMoves.indexOf(Number(ai))==-1 && computerMoves.indexOf(Number(ai))==-1)
 								break;
 						}


### PR DESCRIPTION
solves #1 

Tested and the issue could appear at every turn not only the third one

The problem was your IA sometimes tried to play 9 (your random was between 1 and 9 included) but your board goes from 0 to 8

Also this solves another problem where the same IA couldn't play on the top left tile for the same reason.